### PR TITLE
fix: crumbs not updating if previously visited

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -9,6 +9,7 @@ const {
   getWithDefault,
   assert,
   deprecate,
+  inject,
   isPresent,
   typeOf,
   setProperties,
@@ -22,14 +23,15 @@ const {
 } = computed;
 
 export default Component.extend({
+  routerService: inject.service('router'),
   layout,
   tagName: 'ol',
   linkable: true,
   reverse: false,
   classNameBindings: ['breadCrumbClass'],
   hasBlock: bool('template').readOnly(),
-  currentUrl: readOnly('applicationRoute.router.url'),
-  currentRouteName: readOnly('applicationRoute.controller.currentRouteName'),
+  currentUrl: readOnly('routerService.currentURL'),
+  currentRouteName: readOnly('routerService.currentRouteName'),
 
   routeHierarchy: computed('currentUrl', 'currentRouteName', 'reverse', {
     get() {


### PR DESCRIPTION
Resolves #124 and makes all tests pass after upgrading to Ember 3