### PR TITLE
resolving dynamic segment test in 2.12

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -33,6 +33,7 @@ export default Component.extend({
 
   routeHierarchy: computed('currentUrl', 'currentRouteName', 'reverse', {
     get() {
+      get(this, 'currentUrl');
       const currentRouteName = getWithDefault(this, 'currentRouteName', false);
 
       assert('[ember-crumbly] Could not find a current route', currentRouteName);

--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -218,7 +218,7 @@ module('Acceptance | ember-crumbly integration test', function(hooks) {
     await click(find('#hansel'));
 
     assert.equal(currentRouteName(), 'foo.bar.baz.show-with-params', 'correct current route name');
-    assert.equal(await findAll('#bootstrapLinkable li')[3].innerText.trim(), 'Hansel McDonald', 'crumb is based on dynamic segment');
+    assert.equal(findAll('#bootstrapLinkable li')[3].innerText.trim(), 'Hansel McDonald', 'crumb is based on dynamic segment');
   });
 
   test('parent route becomes linkable when navigating to child', async function(assert) {


### PR DESCRIPTION
Fixing a failing 2.12 test for [#138](https://github.com/poteto/ember-crumbly/pull/138); normally I wouldn't PR a PR, but it seems like I've got time.

If you never `get` a property, `computed` won't fire for it; I thought it was true for all versions of ember, but I guess support improved after 2.12.